### PR TITLE
Add ext-mbstring requirement on composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         }
     ],
     "require": {
-        "php": ">=7.0"
+        "php": ">=7.0",
+        "ext-mbstring": "*"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
# Changed log

- As title, it should add `ext-mbstring` extension checking on `composer.json` because the package requires this extension.